### PR TITLE
Alter applicationId for debug builds.

### DIFF
--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -14,6 +14,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix '.dev'
+            versionNameSuffix '-dev'
+        }
         release {
             runProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
This allows both release and debug builds to be installed side-by-side.
