### PR TITLE
Skip the memory cache for the large background image.

### DIFF
--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/fragment/BrowseFragment.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/fragment/BrowseFragment.java
@@ -294,6 +294,7 @@ public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragm
                 .load(R.drawable.amphitheatre)
                 .resize(mMetrics.widthPixels, mMetrics.heightPixels)
                 .centerCrop()
+                .skipMemoryCache()
                 .into(mBackgroundTarget);
     }
 


### PR DESCRIPTION
This prevents blowing out the memory cache for a massive image that is likely to only be loaded once.
