### PR TITLE
Actually skip the memory cache for background loads of images.

### DIFF
--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/fragment/BrowseFragment.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/fragment/BrowseFragment.java
@@ -194,6 +194,7 @@ public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragm
                 .load(uri.toString())
                 .resize(mMetrics.widthPixels, mMetrics.heightPixels)
                 .centerCrop()
+                .skipMemoryCache()
                 .error(mDefaultBackground)
                 .into(mBackgroundTarget);
     }


### PR DESCRIPTION
The other PR only skipped the cache for loading the initial background image.
