### PR TITLE
Clear Selected Row's Background When User Navigates away, Fixes #18

### DIFF
--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/activity/BrowseActivity.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/activity/BrowseActivity.java
@@ -23,26 +23,10 @@ import com.jerrellmardis.amphitheatre.R;
 
 public class BrowseActivity extends Activity {
 
-    private BackPressedCallback mBackPressedCallbacks;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_browse);
 
-        mBackPressedCallbacks = (BackPressedCallback) getFragmentManager().findFragmentById(R.id.main_browse_fragment);
-    }
-
-    public interface BackPressedCallback {
-        public void onBackPressedCallback();
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-
-        if (mBackPressedCallbacks != null) {
-            mBackPressedCallbacks.onBackPressedCallback();
-        }
     }
 }

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/fragment/BrowseFragment.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/fragment/BrowseFragment.java
@@ -51,7 +51,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,8 +61,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragment implements
-        BrowseActivity.BackPressedCallback {
+public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragment {
 
     private final Handler mHandler = new Handler();
 
@@ -74,6 +72,7 @@ public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragm
     private URI mBackgroundURI;
     private List<Movie> mVideos;
     private List<Movie> mUnmatchedVideos;
+
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
@@ -122,6 +121,19 @@ public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragm
                     }
                 }
             }
+        };
+    }
+
+    private BrowseTransitionListener getBrowseTransitionListener() {
+        return new BrowseTransitionListener() {
+
+            @Override
+            public void onHeadersTransitionStop(boolean withHeaders) {
+                if (withHeaders) {
+                    resetBackground();
+                }
+            }
+
         };
     }
 
@@ -336,6 +348,7 @@ public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragm
                 startActivity(intent);
             }
         });
+        setBrowseTransitionListener(getBrowseTransitionListener());
     }
 
     private void startBackgroundTimer() {
@@ -344,11 +357,6 @@ public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragm
         }
         mBackgroundTimer = new Timer();
         mBackgroundTimer.schedule(new UpdateBackgroundTask(), 300);
-    }
-
-    @Override
-    public void onBackPressedCallback() {
-        this.resetBackground();
     }
 
     private class UpdateBackgroundTask extends TimerTask {
@@ -391,4 +399,5 @@ public class BrowseFragment extends android.support.v17.leanback.app.BrowseFragm
         @Override
         public void onUnbindViewHolder(ViewHolder viewHolder) { }
     }
+
 }


### PR DESCRIPTION
- Added `resetBackground()` method in `BrowseFragment` to reset the background image to the default image, `amphitheater.png`
- Overwrote `onResume` method in `BrowseFragment` and called `resetBackground()` in it so when user navigates away from the `DetailsActivity` the background is reset to the default one.
- Defined an interface in `BrowseActivty`  and implemented it in `BrowseFragements`
- In `BrowseActivity` overwrote `onBackPressed()` to call the interface's method so the background is reset to the default when the user presses the back menu.

To Test.
Select an item in the row and see the background change, navigate away from it by pressing the back menu and see the default background show
