### PR TITLE
Add TVDB support. Fixes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ You'll need to sign up as a developer and add your TMDb API Key to your `~/.grad
 TMDB_API_KEY=<your api key>
 ```
 
+You'll also need to sign up for a [TVDB API Key](http://thetvdb.com/wiki/index.php/Programmers_API) and add it to your `~/.gradle/gradle.properties`:
+```
+TVDB_API_KEY=<your api key>
+```
+
 #### Media Player
 
 Amphitheatre does not play the actual video file but serves it to a capable media player application. So you'll need to install a media player as well. MXPlayer is a great player worth checking out.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.0'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 03 13:04:48 CST 2014
+#Wed Dec 24 14:23:38 JST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     compile 'com.android.support:palette-v7:21.0.0'
     compile 'com.squareup.picasso:picasso:2.3.4'
     compile 'com.squareup.retrofit:retrofit:1.7.1'
+    compile 'com.mobprofs:retrofit-simplexmlconverter:1.1'
     compile 'com.google.code.gson:gson:2.3'
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'org.apache.commons:commons-collections4:4.0'

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -25,7 +25,7 @@ android {
             versionNameSuffix '-dev'
         }
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:21.0.0'
     compile 'com.android.support:palette-v7:21.0.0'
     compile 'com.squareup.picasso:picasso:2.3.4'
-    compile 'com.squareup.retrofit:retrofit:1.7.1'
+    compile 'com.squareup.retrofit:retrofit:1.8.0'
     compile 'com.mobprofs:retrofit-simplexmlconverter:1.1'
     compile 'com.google.code.gson:gson:2.3'
     compile 'org.apache.commons:commons-lang3:3.3.2'

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -55,10 +55,10 @@ dependencies {
     compile 'com.android.support:palette-v7:21.0.0'
     compile 'com.squareup.picasso:picasso:2.3.4'
     compile 'com.squareup.retrofit:retrofit:1.8.0'
-    compile 'com.mobprofs:retrofit-simplexmlconverter:1.1'
     compile 'com.google.code.gson:gson:2.3'
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'org.apache.commons:commons-collections4:4.0'
     compile 'com.jakewharton:butterknife:6.0.0'
     compile 'com.github.satyan:sugar:1.3'
+    compile 'com.squareup.retrofit:converter-simplexml:1.8.0'
 }

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -6,7 +6,7 @@ def loadSecret(String name) {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.0.2"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         applicationId "com.jerrellmardis.amphitheatre"
@@ -46,6 +46,10 @@ android {
         exclude 'META-INF/NOTICE'
         exclude 'META-INF/NOTICE.txt'
     }
+
+    lintOptions {
+        abortOnError = false
+    }
 }
 
 dependencies {
@@ -62,6 +66,8 @@ dependencies {
     compile 'com.jakewharton:butterknife:6.0.0'
     compile 'com.github.satyan:sugar:1.3'
     compile ('com.squareup.retrofit:converter-simplexml:1.8.0') {
+        //Exclude these otherwise the conflict with simplexml classes shipped with core
         exclude group: 'xpp3', module: 'xpp3'
+        exclude group: 'stax', module: 'stax-api'
     }
 }

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -17,6 +17,7 @@ android {
         renderscriptTargetApi 19
 
         buildConfigField "String", "TMDB_API_KEY", "\"${loadSecret("TMDB_API_KEY")}\""
+        buildConfigField "String", "TVDB_API_KEY", "\"${loadSecret("TVDB_API_KEY")}\""
     }
 
     buildTypes {
@@ -60,5 +61,7 @@ dependencies {
     compile 'org.apache.commons:commons-collections4:4.0'
     compile 'com.jakewharton:butterknife:6.0.0'
     compile 'com.github.satyan:sugar:1.3'
-    compile 'com.squareup.retrofit:converter-simplexml:1.8.0'
+    compile ('com.squareup.retrofit:converter-simplexml:1.8.0') {
+        exclude group: 'xpp3', module: 'xpp3'
+    }
 }

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     compile 'com.jakewharton:butterknife:6.0.0'
     compile 'com.github.satyan:sugar:1.3'
     compile ('com.squareup.retrofit:converter-simplexml:1.8.0') {
-        //Exclude these otherwise the conflict with simplexml classes shipped with core
+        //Exclude these otherwise they conflict with some classes shipped with core
         exclude group: 'xpp3', module: 'xpp3'
         exclude group: 'stax', module: 'stax-api'
     }

--- a/tv/src/androidTest/java/com/jerrellmardis/amphitheatre/api/TVDBClientTest.java
+++ b/tv/src/androidTest/java/com/jerrellmardis/amphitheatre/api/TVDBClientTest.java
@@ -1,0 +1,36 @@
+package com.jerrellmardis.amphitheatre.api;
+
+import com.jerrellmardis.amphitheatre.model.tmdb.SearchResult;
+import com.jerrellmardis.amphitheatre.model.tmdb.Episode;
+
+import android.test.AndroidTestCase;
+
+/**
+ * Tests TVDB client
+ */
+public class TVDBClientTest extends AndroidTestCase {
+
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+
+    public void testShouldSearchForHeroesSeries() {
+        SearchResult searchResult = ApiClient.getInstance().createTVDBClient().findTvShow("Heroes");
+        assertNotNull(searchResult);
+        assertEquals(searchResult.getTotal_results(), Integer.valueOf(23));
+        assertNotNull(searchResult.getResults());
+        assertEquals(searchResult.getResults().get(0).getName(), "Heroes");
+    }
+
+    public void testShouldFetchHeroesEpisode() {
+        Long seriesid = 79501l;
+        Long id = 308906l;
+        Episode episode= ApiClient.getInstance().createTVDBClient().getEpisode(seriesid,"2006-09-25");
+        assertNotNull(episode);
+        assertEquals(episode.getId(),id);
+        assertEquals(episode.getAirDate(), "2006-09-25");
+        assertEquals(episode.getName(), "Genesis");
+        assertEquals(episode.getTmdbId(), seriesid);
+    }
+}

--- a/tv/src/androidTest/java/com/jerrellmardis/amphitheatre/api/TVDBClientTest.java
+++ b/tv/src/androidTest/java/com/jerrellmardis/amphitheatre/api/TVDBClientTest.java
@@ -10,11 +10,6 @@ import android.test.AndroidTestCase;
  */
 public class TVDBClientTest extends AndroidTestCase {
 
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
-
     public void testShouldSearchForHeroesSeries() {
         SearchResult searchResult = ApiClient.getInstance().createTVDBClient().findTvShow("Heroes");
         assertNotNull(searchResult);

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/ApiClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/ApiClient.java
@@ -1,7 +1,7 @@
 package com.jerrellmardis.amphitheatre.api;
 
 /**
- * @author Ushahidi Team <team@ushahidi.com>
+ * For access the different media clients available
  */
 public class ApiClient {
 

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/ApiClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/ApiClient.java
@@ -1,0 +1,20 @@
+package com.jerrellmardis.amphitheatre.api;
+
+/**
+ * @author Ushahidi Team <team@ushahidi.com>
+ */
+public class ApiClient {
+
+    private static MediaClientFactory instance = null;
+
+    private ApiClient() {
+
+    }
+
+    public static synchronized MediaClientFactory getInstance() {
+        if (instance == null) {
+            instance = new MediaClientFactory();
+        }
+        return instance;
+    }
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.jerrellmardis.amphitheatre.api;
 

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
@@ -24,6 +24,8 @@ public interface MediaClient {
 
     public Episode getEpisode(Long id, int seasonNumber, int episodeNumber);
 
+    public Episode getEpisode(Long id);
+
     /**
      * Adds the best trailer to the movie record.
      *

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
@@ -24,7 +24,7 @@ public interface MediaClient {
 
     public Episode getEpisode(Long id, int seasonNumber, int episodeNumber);
 
-    public Episode getEpisode(Long id);
+    public Episode getEpisode(Long id, String airDate);
 
     /**
      * Adds the best trailer to the movie record.

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClient.java
@@ -1,0 +1,36 @@
+
+package com.jerrellmardis.amphitheatre.api;
+
+import com.jerrellmardis.amphitheatre.model.tmdb.Config;
+import com.jerrellmardis.amphitheatre.model.tmdb.Episode;
+import com.jerrellmardis.amphitheatre.model.tmdb.Movie;
+import com.jerrellmardis.amphitheatre.model.tmdb.SearchResult;
+import com.jerrellmardis.amphitheatre.model.tmdb.TvShow;
+
+/**
+ * Media data source.
+ */
+public interface MediaClient {
+
+    public Config getConfig();
+
+    public Movie getMovie(Long id);
+
+    public TvShow getTvShow(Long id);
+
+    public SearchResult findMovie(CharSequence name, Integer year);
+
+    public SearchResult findTvShow(CharSequence name);
+
+    public Episode getEpisode(Long id, int seasonNumber, int episodeNumber);
+
+    /**
+     * Adds the best trailer to the movie record.
+     *
+     * Currently, 'best' is defined as the first trailer from YouTube.
+     *
+     * @param movie The movie for which to fetch a trailer.
+     * @return The same movie with the trailer property set.
+     */
+    public Movie addBestTrailer(Movie movie);
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClientFactory.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClientFactory.java
@@ -1,0 +1,15 @@
+package com.jerrellmardis.amphitheatre.api;
+
+/**
+ * Create the media client type to use.
+ */
+public class MediaClientFactory {
+
+    public MediaClient createTMDbClient() {
+        return new TMDbClient();
+    }
+
+    public MediaClient createTVDBClient() {
+        return new TVDBClient();
+    }
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClientFactory.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/MediaClientFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.api;
 
 /**

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TMDbClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TMDbClient.java
@@ -114,7 +114,7 @@ public class TMDbClient implements MediaClient {
     }
 
     @Override
-    public Episode getEpisode(Long id) {
+    public Episode getEpisode(Long id, String airDate) {
         //Do nothing
         return null;
     }

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TMDbClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TMDbClient.java
@@ -113,6 +113,12 @@ public class TMDbClient implements MediaClient {
         return getService().getEpisode(id, seasonNumber, episodeNumber);
     }
 
+    @Override
+    public Episode getEpisode(Long id) {
+        //Do nothing
+        return null;
+    }
+
     /**
      * Adds the best trailer to the movie record.
      *

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
@@ -94,11 +94,9 @@ public class TVDBClient implements MediaClient {
 
         EpisodeResponse episodeResponse = getService().getEpisode(
                 ApiConstants.TVDB_SERVER_API_KEY, id, airDate);
-        System.out.println("Episodes "+episodeResponse.toString());
         if(episodeResponse !=null) {
             com.jerrellmardis.amphitheatre.model.tvdb.Episode tvdbEpisode = episodeResponse
                   .getEpisode();
-            System.out.println("Episodess: "+tvdbEpisode.toString());
             if (tvdbEpisode != null) {
                 Episode episode = new Episode();
                 episode.setName(tvdbEpisode.getEpisodeName());

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2014 Jerrell Mardis
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.jerrellmardis.amphitheatre.api;
 
 import com.google.gson.FieldNamingPolicy;
@@ -36,11 +20,11 @@ import retrofit.http.Path;
 import retrofit.http.Query;
 
 /**
- * Created by Jerrell Mardis on 7/8/14.
+ * HTTP client for the TVDB API
  */
-public class TMDbClient implements MediaClient {
+public class TVDBClient implements MediaClient{
 
-    private interface TMDbService {
+    private interface TVDBService {
         @GET("/configuration")
         Config getConfig();
 
@@ -55,7 +39,7 @@ public class TMDbClient implements MediaClient {
 
         @GET("/tv/{id}/season/{season_number}/episode/{episode_number}")
         Episode getEpisode(@Path("id") Long id, @Path("season_number") int seasonNumber,
-                           @Path("episode_number") int episodeNumber);
+                @Path("episode_number") int episodeNumber);
 
         @GET("/search/movie")
         SearchResult findMovie(@Query("query") CharSequence name, @Query("year") Integer year);
@@ -64,9 +48,9 @@ public class TMDbClient implements MediaClient {
         SearchResult findTvShow(@Query("query") CharSequence name);
     }
 
-    private static TMDbService service;
+    private static TVDBService service;
 
-    private static TMDbService getService() {
+    private static TVDBService getService() {
         Gson gson = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
@@ -82,58 +66,43 @@ public class TMDbClient implements MediaClient {
                         }
                     })
                     .build();
-            service = restAdapter.create(TMDbService.class);
+            service = restAdapter.create(TVDBService.class);
         }
         return service;
     }
 
+    @Override
     public Config getConfig() {
-        return getService().getConfig();
+        return null;
     }
 
+    @Override
     public Movie getMovie(Long id) {
-        Movie movie = getService().getMovie(id);
-        addBestTrailer(movie);
-        return movie;
+        return null;
     }
 
+    @Override
     public TvShow getTvShow(Long id) {
-        return getService().getTvShow(id);
+        return null;
     }
 
+    @Override
     public SearchResult findMovie(CharSequence name, Integer year) {
-        return getService().findMovie(name, year);
+        return null;
     }
 
+    @Override
     public SearchResult findTvShow(CharSequence name) {
-        return getService().findTvShow(name);
+        return null;
     }
 
+    @Override
     public Episode getEpisode(Long id, int seasonNumber, int episodeNumber) {
-        return getService().getEpisode(id, seasonNumber, episodeNumber);
+        return null;
     }
 
-    /**
-     * Adds the best trailer to the movie record.
-     *
-     * Currently, 'best' is defined as the first trailer from YouTube.
-     *
-     * @param movie The movie for which to fetch a trailer.
-     * @return The same movie with the trailer property set.
-     */
+    @Override
     public Movie addBestTrailer(Movie movie) {
-        Videos vids = getService().getVideos(movie.getId());
-        if (vids == null || vids.getResults() == null || vids.getResults().isEmpty()) {
-            return movie;
-        }
-
-        for (Videos.Video vid : vids.getResults()) {
-            if (vid.getType().equals("Trailer") && vid.getSite().equals("YouTube")) {
-                movie.setTrailer(String.format("http://youtube.com/watch?v=%s", vid.getKey()));
-                break;
-            }
-        }
-
-        return movie;
+        return null;
     }
 }

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
@@ -15,6 +15,7 @@ import com.jerrellmardis.amphitheatre.util.ApiConstants;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 import retrofit.converter.GsonConverter;
+import retrofit.converter.SimpleXMLConverter;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
@@ -51,13 +52,10 @@ public class TVDBClient implements MediaClient{
     private static TVDBService service;
 
     private static TVDBService getService() {
-        Gson gson = new GsonBuilder()
-                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create();
 
         if (service == null) {
             RestAdapter restAdapter = new RestAdapter.Builder()
-                    .setConverter(new GsonConverter(gson))
+                    .setConverter(new SimpleXMLConverter() )
                     .setEndpoint(ApiConstants.TMDB_SERVER_URL)
                     .setRequestInterceptor(new RequestInterceptor() {
                         @Override

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
@@ -60,7 +60,7 @@ public class TVDBClient implements MediaClient{
                     .setRequestInterceptor(new RequestInterceptor() {
                         @Override
                         public void intercept(RequestFacade request) {
-                            request.addQueryParam("api_key", ApiConstants.TMDB_SERVER_API_KEY);
+                            request.addQueryParam("api_key", ApiConstants.TVDB_SERVER_API_KEY);
                         }
                     })
                     .build();

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.api;
 
 import com.jerrellmardis.amphitheatre.model.tmdb.Config;

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBClient.java
@@ -1,20 +1,20 @@
 package com.jerrellmardis.amphitheatre.api;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import com.jerrellmardis.amphitheatre.model.tmdb.Config;
 import com.jerrellmardis.amphitheatre.model.tmdb.Episode;
 import com.jerrellmardis.amphitheatre.model.tmdb.Movie;
 import com.jerrellmardis.amphitheatre.model.tmdb.SearchResult;
 import com.jerrellmardis.amphitheatre.model.tmdb.TvShow;
 import com.jerrellmardis.amphitheatre.model.tmdb.Videos;
+import com.jerrellmardis.amphitheatre.model.tvdb.Language;
+import com.jerrellmardis.amphitheatre.model.tvdb.Series;
+import com.jerrellmardis.amphitheatre.model.tvdb.SeriesResult;
 import com.jerrellmardis.amphitheatre.util.ApiConstants;
 
-import retrofit.RequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
+
 import retrofit.RestAdapter;
-import retrofit.converter.GsonConverter;
 import retrofit.converter.SimpleXMLConverter;
 import retrofit.http.GET;
 import retrofit.http.Path;
@@ -26,27 +26,18 @@ import retrofit.http.Query;
 public class TVDBClient implements MediaClient{
 
     private interface TVDBService {
-        @GET("/configuration")
-        Config getConfig();
-
-        @GET("/movie/{id}")
-        Movie getMovie(@Path("id") Long id);
-
-        @GET("/movie/{id}/videos")
-        Videos getVideos(@Path("id") Long id);
-
-        @GET("/tv/{id}")
-        TvShow getTvShow(@Path("id") Long id);
-
-        @GET("/tv/{id}/season/{season_number}/episode/{episode_number}")
-        Episode getEpisode(@Path("id") Long id, @Path("season_number") int seasonNumber,
-                @Path("episode_number") int episodeNumber);
+        
+        @GET("/{apikey}/series/{seriesid}/{language}")
+        com.jerrellmardis.amphitheatre.model.tvdb.Episode getEpisode(@Query("apikey") String apiKey,
+                @Query("seriesid") long seriesId, @Query("language") Language language);
 
         @GET("/search/movie")
         SearchResult findMovie(@Query("query") CharSequence name, @Query("year") Integer year);
 
-        @GET("/search/tv")
-        SearchResult findTvShow(@Query("query") CharSequence name);
+        // Search for series
+        @GET("/GetSeries.php")
+        SeriesResult findTvShow(@Query("seriesname") String seriesName,
+                @Query("language") Language language);
     }
 
     private static TVDBService service;
@@ -55,14 +46,8 @@ public class TVDBClient implements MediaClient{
 
         if (service == null) {
             RestAdapter restAdapter = new RestAdapter.Builder()
-                    .setConverter(new SimpleXMLConverter() )
-                    .setEndpoint(ApiConstants.TMDB_SERVER_URL)
-                    .setRequestInterceptor(new RequestInterceptor() {
-                        @Override
-                        public void intercept(RequestFacade request) {
-                            request.addQueryParam("api_key", ApiConstants.TVDB_SERVER_API_KEY);
-                        }
-                    })
+                    .setConverter(new SimpleXMLConverter())
+                    .setEndpoint(ApiConstants.TVDB_SERVER_URL)
                     .build();
             service = restAdapter.create(TVDBService.class);
         }
@@ -71,36 +56,76 @@ public class TVDBClient implements MediaClient{
 
     @Override
     public Config getConfig() {
+        //Do nothing
         return null;
     }
 
     @Override
     public Movie getMovie(Long id) {
+        // Do nothing
         return null;
     }
 
     @Override
     public TvShow getTvShow(Long id) {
+        // Do nothing
         return null;
     }
 
     @Override
     public SearchResult findMovie(CharSequence name, Integer year) {
+        // Do nothing
         return null;
     }
 
     @Override
     public SearchResult findTvShow(CharSequence name) {
-        return null;
+        // Fetch series details from tvdb
+        SeriesResult seriesResult = getService().findTvShow(name.toString(), Language.ENGLISH);
+        return map(seriesResult);
+    }
+
+    @Override
+    public Episode getEpisode(Long id) {
+        return this.getEpisode(id, 0, 0);
     }
 
     @Override
     public Episode getEpisode(Long id, int seasonNumber, int episodeNumber) {
-        return null;
+        com.jerrellmardis.amphitheatre.model.tvdb.Episode tvdbEpisode = getService().getEpisode(
+                ApiConstants.TVDB_SERVER_API_KEY, id, Language.ALL);
+        Episode episode = new Episode();
+        episode.setName(tvdbEpisode.getName());
+        episode.setAirDate(tvdbEpisode.getFirstAiringDate());
+        episode.setOverview(tvdbEpisode.getDescription());
+        episode.setSeasonNumber(tvdbEpisode.getSeasonNumber());
+        episode.setStillPath(tvdbEpisode.getImageUrl());
+        //Use Series id as TMDbId
+        episode.setTmdbId(tvdbEpisode.getId());
+        episode.setId(tvdbEpisode.getId());
+
+        return episode;
     }
 
     @Override
     public Movie addBestTrailer(Movie movie) {
+        //Do nothing
         return null;
+    }
+
+    private SearchResult map(SeriesResult seriesResult) {
+        // Map series search results unto tmdb movie result details
+        List<SearchResult.Result> results = new ArrayList<>();
+        for (Series series : seriesResult.getSeries()) {
+            SearchResult.Result result = new SearchResult.Result();
+            result.setName(series.getSeriesName());
+            result.setId(Long.valueOf(series.getId()));
+            result.setPoster_path(series.getPosters());
+            results.add(result);
+        }
+        SearchResult searchResult = new SearchResult();
+        searchResult.setTotal_results(seriesResult.getSeries().size());
+        searchResult.setResults(results);
+        return searchResult;
     }
 }

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBService.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBService.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.api;
 
-import com.jerrellmardis.amphitheatre.model.tvdb.Episode;
 import com.jerrellmardis.amphitheatre.model.tvdb.EpisodeResponse;
 import com.jerrellmardis.amphitheatre.model.tvdb.Language;
 import com.jerrellmardis.amphitheatre.model.tvdb.SeriesResult;
 
 import retrofit.http.GET;
-import retrofit.http.Path;
 import retrofit.http.Query;
 
 public interface TVDBService {

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBService.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/api/TVDBService.java
@@ -1,0 +1,21 @@
+package com.jerrellmardis.amphitheatre.api;
+
+import com.jerrellmardis.amphitheatre.model.tvdb.Episode;
+import com.jerrellmardis.amphitheatre.model.tvdb.EpisodeResponse;
+import com.jerrellmardis.amphitheatre.model.tvdb.Language;
+import com.jerrellmardis.amphitheatre.model.tvdb.SeriesResult;
+
+import retrofit.http.GET;
+import retrofit.http.Path;
+import retrofit.http.Query;
+
+public interface TVDBService {
+
+    @GET("/GetEpisodeByAirDate.php")
+    EpisodeResponse getEpisode(@Query("apikey") String apiKey, @Query("seriesid") Long seriesId, @Query("airdate") String airDate);
+
+    // Search for series
+    @GET("/GetSeries.php")
+    SeriesResult findTvShow(@Query("seriesname") String seriesName,
+            @Query("language") Language language);
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
@@ -21,6 +21,7 @@ import org.simpleframework.xml.Root;
 
 @Root(strict = false)
 public abstract class BaseResponse {
+
     @Element(name = "id", required = false)
     private Long mId;
 

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.model.tvdb;
 
 import org.simpleframework.xml.Element;

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
@@ -1,0 +1,67 @@
+package com.jerrellmardis.amphitheatre.model.tvdb;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+@Root(strict = false)
+public abstract class BaseResponse {
+    @Element(name = "id", required = false)
+    private Long mId;
+
+    @Element(name = "IMDB_ID", required = false)
+    private String mImdbId;
+
+    @Element(name = "language", required = false)
+    private String mLanguage;
+
+    @Element(name = "Overview", required = false)
+    private String mDescription;
+
+    @Element(name = "Rating", required = false)
+    private float mRating;
+
+    @Element(name = "RatingCount", required = false)
+    private int mRatingCount;
+
+    @Element(name = "lastupdated", required = false)
+    private long mLastUpdated;
+
+    @Element(name = "FirstAired", required = false)
+    private String mFirstAiringDate;
+
+    public Long getId() {
+        return mId;
+    }
+
+    public String getImdbId() {
+        return mImdbId;
+    }
+
+    public String getRawLanguage() {
+        return mLanguage;
+    }
+
+    public Language getLanguage() {
+        return Language.parse(mLanguage);
+    }
+
+    public String getDescription() {
+        return mDescription;
+    }
+
+    public float getRating() {
+        return mRating;
+    }
+
+    public int getRatingCount() {
+        return mRatingCount;
+    }
+
+    public long getLastUpdated() {
+        return mLastUpdated;
+    }
+
+    public String getFirstAiringDate() {
+        return mFirstAiringDate;
+    }
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/BaseResponse.java
@@ -64,4 +64,18 @@ public abstract class BaseResponse {
     public String getFirstAiringDate() {
         return mFirstAiringDate;
     }
+
+    @Override
+    public String toString() {
+        return "BaseResponse{" +
+                "mId=" + mId +
+                ", mImdbId='" + mImdbId + '\'' +
+                ", mLanguage='" + mLanguage + '\'' +
+                ", mDescription='" + mDescription + '\'' +
+                ", mRating=" + mRating +
+                ", mRatingCount=" + mRatingCount +
+                ", mLastUpdated=" + mLastUpdated +
+                ", mFirstAiringDate='" + mFirstAiringDate + '\'' +
+                '}';
+    }
 }

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Episode.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Episode.java
@@ -1,0 +1,29 @@
+package com.jerrellmardis.amphitheatre.model.tvdb;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+@Root(name = "Episode", strict = false)
+public class Episode extends BaseResponse {
+
+    @Element(name = "EpisodeName", required = false)
+    private String mName;
+
+    @Element(name = "SeasonNumber", required = false)
+    private int mSeasonNumber;
+
+    @Element(name = "filename", required = false)
+    private String mImageUrl;
+
+    public String getName() {
+        return mName;
+    }
+
+    public int getSeasonNumber() {
+        return mSeasonNumber;
+    }
+
+    public String getImageUrl() {
+        return mImageUrl;
+    }
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Episode.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Episode.java
@@ -7,7 +7,10 @@ import org.simpleframework.xml.Root;
 public class Episode extends BaseResponse {
 
     @Element(name = "EpisodeName", required = false)
-    private String mName;
+    private String mEpisodeName;
+
+    @Element(name = "EpisodeNumber", required = false)
+    private Long mEpisodeNumber;
 
     @Element(name = "SeasonNumber", required = false)
     private int mSeasonNumber;
@@ -15,8 +18,18 @@ public class Episode extends BaseResponse {
     @Element(name = "filename", required = false)
     private String mImageUrl;
 
-    public String getName() {
-        return mName;
+    @Element(name = "seasonid", required = false)
+    private Long mSeasonId;
+
+    @Element(name = "seriesid", required = false)
+    private Long mSeriesId;
+
+    public String getEpisodeName() {
+        return mEpisodeName;
+    }
+
+    public Long getEpisodeNumber() {
+        return mEpisodeNumber;
     }
 
     public int getSeasonNumber() {
@@ -25,5 +38,25 @@ public class Episode extends BaseResponse {
 
     public String getImageUrl() {
         return mImageUrl;
+    }
+
+    public Long getSeasonId() {
+        return mSeasonId;
+    }
+
+    public Long getSeriesId() {
+        return mSeriesId;
+    }
+
+    @Override
+    public String toString() {
+        return "Episode{" +
+                "mEpisodeName='" + mEpisodeName + '\'' +
+                ", mEpisodeNumber=" + mEpisodeNumber +
+                ", mSeasonNumber=" + mSeasonNumber +
+                ", mImageUrl='" + mImageUrl + '\'' +
+                ", mSeasonId=" + mSeasonId +
+                ", mSeriesId=" + mSeriesId +
+                '}';
     }
 }

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Episode.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Episode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.model.tvdb;
 
 import org.simpleframework.xml.Element;

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/EpisodeResponse.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/EpisodeResponse.java
@@ -1,0 +1,22 @@
+package com.jerrellmardis.amphitheatre.model.tvdb;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+@Root(name = "Data", strict = false)
+public class EpisodeResponse {
+
+    @Element(name = "Episode", required = false)
+    private Episode mEpisode;
+
+    public Episode getEpisode() {
+        return mEpisode;
+    }
+
+    @Override
+    public String toString() {
+        return "EpisodeResponse{" +
+                "mEpisode=" + mEpisode +
+                '}';
+    }
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/EpisodeResponse.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/EpisodeResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.model.tvdb;
 
 import org.simpleframework.xml.Element;

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Language.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Language.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.model.tvdb;
 
 public enum Language {

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Language.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Language.java
@@ -1,0 +1,38 @@
+package com.jerrellmardis.amphitheatre.model.tvdb;
+
+public enum Language {
+    ALL(0, "all"),
+    ENGLISH(7, "en");
+
+    private int mId;
+
+    private String mCode;
+
+    private Language(int id, String code) {
+        mId = id;
+        mCode = code;
+    }
+
+    public static Language parse(String code) {
+        for (Language language : values()) {
+            if (language.getCode().equalsIgnoreCase(code)) {
+                return language;
+            }
+        }
+        return null;
+    }
+
+    public int getId() {
+        return mId;
+    }
+
+    public String getCode() {
+        return mCode;
+    }
+
+    @Override
+    public String toString() {
+        return mCode;
+    }
+
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Series.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Series.java
@@ -1,0 +1,46 @@
+package com.jerrellmardis.amphitheatre.model.tvdb;
+
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+@Root(name = "Series", strict = false)
+public class Series extends BaseResponse {
+    @Element(name = "seriesid", required = false)
+    private int mSeriesId;
+
+    @Element(name = "SeriesName", required = false)
+    private String mSeriesName;
+
+    @Element(name = "banner", required = false)
+    private String mImageUrl;
+
+    @Element(name = "posters", required = false)
+    private String mPosters;
+
+    public int getSeriesId() {
+        return mSeriesId;
+    }
+
+    public String getSeriesName() {
+        return mSeriesName;
+    }
+
+    public String getImageUrl() {
+        return mImageUrl;
+    }
+
+    public String getPosters() {
+        return mPosters;
+    }
+
+    @Override
+    public String toString() {
+        return "Series{" +
+                "mSeriesId=" + mSeriesId +
+                ", mSeriesName='" + mSeriesName + '\'' +
+                ", mImageUrl='" + mImageUrl + '\'' +
+                ", mPosters='" + mPosters + '\'' +
+                '}';
+    }
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Series.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Series.java
@@ -21,6 +21,7 @@ import org.simpleframework.xml.Root;
 
 @Root(name = "Series", strict = false)
 public class Series extends BaseResponse {
+
     @Element(name = "seriesid", required = false)
     private int mSeriesId;
 

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Series.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/Series.java
@@ -1,5 +1,20 @@
-package com.jerrellmardis.amphitheatre.model.tvdb;
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package com.jerrellmardis.amphitheatre.model.tvdb;
 
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/SeriesResult.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/SeriesResult.java
@@ -1,0 +1,17 @@
+package com.jerrellmardis.amphitheatre.model.tvdb;
+
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "Data", strict = false)
+public class SeriesResult {
+
+    @ElementList(name = "Series", inline = true, required = false)
+    private List<Series> mSeries;
+
+    public List<Series> getSeries() {
+        return mSeries;
+    }
+}

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/SeriesResult.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/model/tvdb/SeriesResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 Jerrell Mardis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jerrellmardis.amphitheatre.model.tvdb;
 
 import org.simpleframework.xml.ElementList;

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/service/LibraryUpdateService.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/service/LibraryUpdateService.java
@@ -20,6 +20,8 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.util.Log;
 
+import com.jerrellmardis.amphitheatre.api.ApiClient;
+import com.jerrellmardis.amphitheatre.api.MediaClientFactory;
 import com.jerrellmardis.amphitheatre.api.TMDbClient;
 import com.jerrellmardis.amphitheatre.model.Source;
 import com.jerrellmardis.amphitheatre.model.Video;
@@ -61,7 +63,7 @@ public class LibraryUpdateService extends IntentService {
                 String user = prefs.getString(Constants.PREFS_USER_KEY, "");
                 String pass = prefs.getString(Constants.PREFS_PASSWORD_KEY, "");
 
-                Config config = TMDbClient.getConfig();
+                Config config = ApiClient.getInstance().createTMDbClient().getConfig();
 
                 for (Source source : sources) {
                     // get a list of files on the device

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/task/DownloadTaskHelper.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/task/DownloadTaskHelper.java
@@ -101,18 +101,9 @@ public final class DownloadTaskHelper {
         if (!TextUtils.isEmpty(guess.getTitle())) {
             try {
                 // search for the movie
-                SearchResult result;
-
-                result = ApiClient
+                SearchResult result = ApiClient
                         .getInstance().createTMDbClient().findMovie(guess.getTitle(),
                                 guess.getYear());
-                if (result == null) {
-
-                    // Use TVDB Client
-                    result = ApiClient
-                            .getInstance().createTVDBClient().findMovie(guess.getTitle(),
-                                    guess.getYear());
-                }
 
                 // if found, get the detailed info for the movie
                 if (result.getResults() != null && !result.getResults().isEmpty()) {
@@ -127,7 +118,8 @@ public final class DownloadTaskHelper {
                         movie.setTmdbId(id);
                         movie.setId(null);
                         movie.setFlattenedGenres(StringUtils.join(movie.getGenres(), ","));
-                        movie.setFlattenedProductionCompanies(StringUtils.join(movie.getProductionCompanies(), ","));
+                        movie.setFlattenedProductionCompanies(
+                                StringUtils.join(movie.getProductionCompanies(), ","));
                         movie.save();
 
                         video.setOverview(movie.getOverview());
@@ -226,10 +218,14 @@ public final class DownloadTaskHelper {
                 if (tmdbId != null) {
                     // get the Episode information
                     if (guess.getEpisodeNumber() != null && guess.getSeason() != null) {
-                        Episode episode = ApiClient.getInstance().createTMDbClient()
+                        Episode episode;
+                        episode = ApiClient.getInstance().createTMDbClient()
                                 .getEpisode(tvShow.getTmdbId(),
                                         guess.getSeason(), guess.getEpisodeNumber());
-
+                        if (episode == null) {
+                            episode = ApiClient.getInstance().createTVDBClient()
+                                    .getEpisode(tvShow.getId());
+                        }
                         if (episode != null) {
                             if (!TextUtils.isEmpty(episode.getStillPath())) {
                                 String stillPathUrl = config.getImages().getBase_url() + "original" +

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/task/DownloadTaskHelper.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/task/DownloadTaskHelper.java
@@ -224,7 +224,7 @@ public final class DownloadTaskHelper {
                                         guess.getSeason(), guess.getEpisodeNumber());
                         if (episode == null) {
                             episode = ApiClient.getInstance().createTVDBClient()
-                                    .getEpisode(tvShow.getId());
+                                    .getEpisode(tvShow.getId(),tvShow.getEpisode().getAirDate());
                         }
                         if (episode != null) {
                             if (!TextUtils.isEmpty(episode.getStillPath())) {

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/task/GetFilesTask.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/task/GetFilesTask.java
@@ -19,6 +19,7 @@ package com.jerrellmardis.amphitheatre.task;
 import android.content.Context;
 import android.os.AsyncTask;
 
+import com.jerrellmardis.amphitheatre.api.ApiClient;
 import com.jerrellmardis.amphitheatre.api.TMDbClient;
 import com.jerrellmardis.amphitheatre.listeners.TaskListener;
 import com.jerrellmardis.amphitheatre.model.tmdb.Config;
@@ -73,7 +74,7 @@ public class GetFilesTask extends AsyncTask<Void, Void, List<SmbFile>> implement
 
     @Override
     protected List<SmbFile> doInBackground(Void... params) {
-        mConfig = TMDbClient.getConfig();
+        mConfig = ApiClient.getInstance().createTMDbClient().getConfig();
         return new ArrayList<SmbFile>(DownloadTaskHelper.getFiles(mUser, mPassword, mPath));
     }
 

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/util/ApiConstants.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/util/ApiConstants.java
@@ -28,6 +28,7 @@ public final class ApiConstants {
     public static final String TMDB_SERVER_URL = "https://api.themoviedb.org/3";
     public static final String TMDB_SERVER_API_KEY = BuildConfig.TMDB_API_KEY;
 
-    public static final String TVDB_SERVER_URL = "http://thetvdb.com/api/";
+    public static final String TVDB_SERVER_URL = "http://thetvdb.com/api";
+
     public static final String TVDB_SERVER_API_KEY = BuildConfig.TVDB_API_KEY;
 }

--- a/tv/src/main/java/com/jerrellmardis/amphitheatre/util/ApiConstants.java
+++ b/tv/src/main/java/com/jerrellmardis/amphitheatre/util/ApiConstants.java
@@ -27,4 +27,7 @@ public final class ApiConstants {
 
     public static final String TMDB_SERVER_URL = "https://api.themoviedb.org/3";
     public static final String TMDB_SERVER_API_KEY = BuildConfig.TMDB_API_KEY;
+
+    public static final String TVDB_SERVER_URL = "http://thetvdb.com/api/";
+    public static final String TVDB_SERVER_API_KEY = BuildConfig.TVDB_API_KEY;
 }


### PR DESCRIPTION
- Upgrade to the latest Android Gradle plugin.
- Add an Interface for the TVDB service.
- Add a basic test cases for testing the TVDB integration.
- Use TVDB client as a fallback if TMDB service fails to fetch details of a TV show or.
- Update README to include where to add TVDB api key

@jerrellmardis @JakeWharton @MizzleDK I finally found some time to work on this. I would appreciate a review. In particular which fields we're interested with the TVDB API.
